### PR TITLE
Do not include the static directory in the Nix derivation

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
     needs: ormolu
     steps:
       - uses: actions/checkout@v4
+        with:
+          lfs: true
       - uses: cachix/install-nix-action@v24
       - uses: cachix/cachix-action@v13
         with:
@@ -36,7 +38,13 @@ jobs:
           fi
           # Netlify does not see a symlink as a directory, so we have to
           # copy the contents.
-          cp -R result/ publish/
+          mkdir publish/
+          cp -R result/* publish/
+          # The images are relatively heavy so we don't want to include them
+          # in the Nix derivation in order to avoid blowing up the Cachix
+          # cache. Therefore, the static/ directory has to be copied
+          # separately.
+          cp -R --parents static/ publish/
       - name: Deploy to Netlify (preview)
         if: github.ref != 'refs/heads/master'
         uses: nwtgck/actions-netlify@v2

--- a/app/Main.hs
+++ b/app/Main.hs
@@ -108,10 +108,7 @@ essayPattern = "essay/*.md"
 essayMapOut :: FilePath -> FilePath
 essayMapOut = (-<.> "html")
 
-cssR,
-  jsR,
-  imgR,
-  notFoundR,
+notFoundR,
   exhibitionsR,
   exhibitionR,
   artR,
@@ -120,9 +117,6 @@ cssR,
   essayR,
   contactR ::
     Route
-cssR = Ins "static/css/*.css" id
-jsR = Ins "static/js/*.js" id
-imgR = Ins "static/img/**/*" id
 notFoundR = Gen "404.html"
 exhibitionsR = Gen "exhibitions.html"
 exhibitionR = GenPat "exhibition/*.html"
@@ -355,9 +349,6 @@ main = shakeArgs shakeOptions $ do
           output
 
   -- Page implementations
-  buildRoute cssR copyFile'
-  buildRoute jsR copyFile'
-  buildRoute imgR copyFile'
   buildRoute notFoundR $ \_ output ->
     justFromTemplate (Left "404 Not Found") "404" output
   buildRoute exhibitionsR $ \_ output -> do

--- a/flake.nix
+++ b/flake.nix
@@ -27,7 +27,6 @@
         "^env\.yaml$"
         "^essay.*$"
         "^exhibitions\.yaml$"
-        "^static.*$"
         "^templates.*$"
       ];
       haskellPackages = pkgs.haskell.packages.${compiler}.override


### PR DESCRIPTION
Including the images in the derivation blows the Cachix cache very quickly since Nix cannot figure that images stay the same. Solution: copy the static/ directory manually after building the main derivation.